### PR TITLE
node.py: Allow custom pid wait timeout

### DIFF
--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -30,6 +30,7 @@ from six.moves import xrange
 logger = logging.getLogger(__name__)
 
 NODE_WAIT_TIMEOUT_IN_SECS = 90
+DEFAULT_UPDATE_PID_TIMEOUT_IN_SECS = int(os.environ.get('CCM_UPDATE_PID_DEFAULT_TIMEOUT', 30))
 
 class Status():
     UNINITIALIZED = "UNINITIALIZED"
@@ -2070,8 +2071,9 @@ class Node(object):
 
         start = time.time()
         while not (os.path.isfile(pidfile) and os.stat(pidfile).st_size > 0):
-            if (time.time() - start > 30.0):
-                common.error("Timed out waiting for pidfile to be filled (current time is {})".format(datetime.now()))
+            if time.time() - start > DEFAULT_UPDATE_PID_TIMEOUT_IN_SECS:
+                common.error("Timed out waiting for pidfile to be filled (timeout is {}, current time is {})"
+                             .format(DEFAULT_UPDATE_PID_TIMEOUT_IN_SECS, datetime.now()))
                 break
             else:
                 time.sleep(0.1)


### PR DESCRIPTION
We had to increase this timeout to have CCM working properly in the GitHub Actions environment [here](https://github.com/JanusGraph/janusgraph/pull/3101/files#diff-4556858d284e06ad2c7958de7081dd04bc48933686dc87baf785ad82217a0242R71-R73).